### PR TITLE
Bug fixes

### DIFF
--- a/src/components/PostList/PostList.tsx
+++ b/src/components/PostList/PostList.tsx
@@ -25,12 +25,9 @@ const PostList = () => {
   const [visibleComments, setVisibleComments] = useState<{ [key: string]: boolean }>({});
 
   useEffect(() => {
-    console.log('Subreddit parameter:', subreddit);
     if (subreddit) {
-      console.log('Fetching posts for subreddit:', subreddit);
       dispatch(fetchSubredditPosts(subreddit));
     } else {
-      console.log('Fetching popular posts');
       dispatch(fetchPosts());
     }
   }, [dispatch, subreddit]);

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,19 +1,17 @@
-import { useState } from 'react';
 import { useAppDispatch } from '../../store';
 import { searchPosts } from '../../features/posts/postsSlice';
 import { setQuery } from '../../features/navigation/navigationSlice';
 import styles from './SearchBar.module.scss';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store';
 
 const SearchBar = () => {
-  const [localQuery, setLocalQuery] = useState('');
+  const localQuery = useSelector((state: RootState) => state.navigation.query);
   const dispatch = useAppDispatch();
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    if (localQuery.trim() === '') {
-      alert('Please enter a search query');
-      return;
-    }
+
     dispatch(setQuery(localQuery));
     dispatch(searchPosts(localQuery));
   };
@@ -27,7 +25,7 @@ const SearchBar = () => {
         <input
           type='text'
           value={localQuery}
-          onChange={(e) => setLocalQuery(e.target.value)}
+          onChange={(e) => dispatch(setQuery(e.target.value))}
           className={styles.input}
           placeholder='Search posts...'
         />

--- a/src/features/posts/postsSlice.ts
+++ b/src/features/posts/postsSlice.ts
@@ -58,6 +58,10 @@ export const searchPosts = createAsyncThunk('posts/searchPosts', async (query: s
         created_utc: child.data.created_utc,
         ups: child.data.ups,
         downs: child.data.downs,
+        thumbnail: child.data.thumbnail,
+        url: child.data.url,
+        preview: child.data.preview,
+        num_comments: child.data.num_comments,
       } as Post)
   );
 });

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -1,4 +1,7 @@
 export const formatNumbers = (numbers: number): string => {
+  if (numbers == null) {
+    return '0';
+  }
   if (numbers >= 1000) {
     return (numbers / 1000).toFixed(1) + 'k';
   }


### PR DESCRIPTION
### Description
This pull request addresses two bugs in the app.

1. **Undefined Error in `formatNumbers` Utility Function**:
    - The `formatNumbers` function was causing an undefined error in the console when the input number was null or undefined.
    - **Fix**: Added an additional check to return '0' if the input number is null or undefined.
    ```typescript
    export const formatNumbers = (numbers: number): string => {
      if (numbers == null) {
        return '0';
      }
      if (numbers >= 1000) {
        return (numbers / 1000).toFixed(1) + 'k';
      }
      return numbers.toString();
    };
    ```

2. **Missing `num_comments`, `url` , `preview` and `thumbnail`  in `searchPosts` Thunk**:
    - The number of comments for posts was not being fetched and displayed as well as images during the search.
    - **Fix**: Added `num_comments`, `url` , `preview` and `thumbnail` to the list of key-value pairs mapped in the `searchPosts` asynchronous thunk.
    ```typescript
    export const searchPosts = createAsyncThunk('posts/searchPosts', async (query: string) => {
      const response = await axios.get(`https://www.reddit.com/search.json?q=${query}`);
      return response.data.data.children.map(
        (child: any) =>
          ({
            id: child.data.id,
            title: child.data.title,
            author: child.data.author,
            created_utc: child.data.created_utc,
            ups: child.data.ups,
            downs: child.data.downs,
            thumbnail: child.data.thumbnail,
            url: child.data.url,
            preview: child.data.preview,
            num_comments: child.data.num_comments,
          } as Post)
      );
    });
    ```

### Testing
- Verified that the `formatNumbers` function no longer throws an undefined error.
- Confirmed that the `num_comments` field is now correctly fetched and displayed for each post during the search.