### PR TITLE
Fix: disable hover effect for vote arrows on mobile

### DIFF
--- a/src/components/Icons/Downvote.module.scss
+++ b/src/components/Icons/Downvote.module.scss
@@ -1,11 +1,18 @@
+@use '../../styles/mixins.scss' as m;
 @import '../../styles/variables.scss';
 
 .downvoteArrow {
   fill: $secondary-color;
-}
 
-.downvoteArrow:hover {
-  fill: $danger-color;
+  &:hover {
+    fill: $danger-color;
+  }
+
+  @include m.breakpoint-max('sm') {
+    &:hover {
+      fill: $secondary-color;
+    }
+  }
 }
 
 .downvoted {

--- a/src/components/Icons/Upvote.module.scss
+++ b/src/components/Icons/Upvote.module.scss
@@ -1,11 +1,18 @@
+@use '../../styles/mixins.scss' as m;
 @import '../../styles/variables.scss';
 
 .upvoteArrow {
   fill: $secondary-color;
-}
 
-.upvoteArrow:hover {
-  fill: $success-color;
+  &:hover {
+    fill: $success-color;
+  }
+
+  @include m.breakpoint-max('sm') {
+    &:hover {
+      fill: $secondary-color;
+    }
+  }
 }
 
 .upvoted {


### PR DESCRIPTION
### Description

This pull request addresses the issue of the upvote and downvote arrows remaining green/red on mobile devices after tapping twice by disabling the hover effect on mobile. This ensures a consistent user experience across different devices.

### Changes Made

- Added a media query to disable the hover effect for the upvote and downvote arrows on devices with a screen width smaller than the `sm` breakpoint.

### Updated SCSS

```scss
@use '../../styles/variables.scss' as m;
@import '../../styles/variables.scss';

.upvoteArrow {
  fill: $secondary-color;
  
  &:hover {
    fill: $success-color;
  }

  @include m.breakpoint-max('sm') {
    &:hover {
      fill: $secondary-color;
    }
  }
}

.upvoted {
  fill: $success-color;
}
```

```scss
@use '../../styles/mixins.scss' as m;
@import '../../styles/variables.scss';

.downvoteArrow {
  fill: $secondary-color;

  &:hover {
    fill: $danger-color;
  }

  @include m.breakpoint-max('sm') {
    &:hover {
      fill: $secondary-color;
    }
  }
}

.downvoted {
  fill: $danger-color;
}
```

#Testing
- Verified that the hover effect is disabled on mobile devices, and the upvote arrow does not stay green after tapping.
- Ensured that the hover effect still works as intended on desktop devices.