### PR TITLE
Fix: adjust back button position top to align with SideBar

### DIFF
--- a/src/components/PostDetails/PostDetails.module.scss
+++ b/src/components/PostDetails/PostDetails.module.scss
@@ -169,7 +169,7 @@
       display: flex;
       justify-content: left;
       align-items: center;
-      top: 11.25rem;
+      top: 10.25rem;
       left: 0;
       width: 100%;
       height: 2.7rem;
@@ -183,7 +183,7 @@
       }
 
       @include m.breakpoint-max('md') {
-        top: 11.25rem;
+        top: 10.25rem;
         left: 0;
       }
 


### PR DESCRIPTION
# Minor Fix

## Description

Adjusted position top of the back button to position it better on small screens.